### PR TITLE
making unchecked constructor of Literal public

### DIFF
--- a/lib/src/model/literal.rs
+++ b/lib/src/model/literal.rs
@@ -76,7 +76,8 @@ impl Literal {
     /// Builds a RDF [language-tagged string](https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string)
     ///
     /// It is the responability of the caller to check that `language`
-    /// is valid [BCP47](https://tools.ietf.org/html/bcp47) language tag.
+    /// is valid [BCP47](https://tools.ietf.org/html/bcp47) language tag,
+    /// and is lowercase.
     ///
     /// If in doubt, you should rather use
     /// [`new_language_tagged_literal`](#method.new_language_tagged_literal).

--- a/lib/src/model/literal.rs
+++ b/lib/src/model/literal.rs
@@ -73,7 +73,14 @@ impl Literal {
         }))
     }
 
-    pub(crate) fn new_language_tagged_literal_unchecked(
+    /// Builds a RDF [language-tagged string](https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string)
+    ///
+    /// It is the responability of the caller to check that `language`
+    /// is valid [BCP47](https://tools.ietf.org/html/bcp47) language tag.
+    ///
+    /// If in doubt, you should rather use
+    /// [`new_language_tagged_literal`](#method.new_language_tagged_literal).
+    pub fn new_language_tagged_literal_unchecked(
         value: impl Into<String>,
         language: impl Into<String>,
     ) -> Self {


### PR DESCRIPTION
for the same reason as before: bindings to other languages/APIs can benefit from this