### PR TITLE
add destruct method to Literal and Quad

### DIFF
--- a/lib/src/model/literal.rs
+++ b/lib/src/model/literal.rs
@@ -133,6 +133,17 @@ impl Literal {
             _ => false,
         }
     }
+
+    /// Extract components from this literal
+    pub fn destruct(self) -> (String, Option<NamedNode>, Option<String>) {
+        match self.0 {
+            LiteralContent::String(s) => (s, None, None),
+            LiteralContent::LanguageTaggedString { value, language } => {
+                (value, None, Some(language))
+            }
+            LiteralContent::TypedLiteral { value, datatype } => (value, Some(datatype), None),
+        }
+    }
 }
 
 impl fmt::Display for Literal {

--- a/lib/src/model/triple.rs
+++ b/lib/src/model/triple.rs
@@ -287,6 +287,11 @@ impl Quad {
     pub fn into_triple(self) -> Triple {
         Triple::new(self.subject, self.predicate, self.object)
     }
+
+    /// Extract components from this quad
+    pub fn destruct(self) -> (NamedOrBlankNode, NamedNode, Term, Option<NamedOrBlankNode>) {
+        (self.subject, self.predicate, self.object, self.graph_name)
+    }
 }
 
 impl fmt::Display for Quad {


### PR DESCRIPTION
This is (again) useful for building bridges to other APIs.

Note that NamedNode already has this (into_string),
that BlankNode kind of has it (id)
and that Quad has incomplete versions of it (subject_owned, predicate_owned...).
So I don't think those are too disruptive.